### PR TITLE
removed user inputs

### DIFF
--- a/index.py
+++ b/index.py
@@ -1,13 +1,29 @@
 """Index bot file"""
+
 from prompt_toolkit import PromptSession
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit import print_formatted_text
 from data_handlers import save_data, load_data
-from models import (AddressBook, NotesManager)
+from models import AddressBook, NotesManager
 from input_handlers import (
-    add_contact, change_contact, remove_contact, show_contact, all_contacts,
-    birthdays, add_birthday, show_birthday, add_email, add_address, show_address,
-    add_note, edit_note, delete_note, show_note, search_note, sort_notes_by_tag
+    add_contact,
+    change_contact,
+    remove_contact,
+    show_contact,
+    all_contacts,
+    birthdays,
+    add_birthday,
+    show_birthday,
+    add_email,
+    add_address,
+    show_address,
+    add_note,
+    add_tag,
+    edit_note,
+    delete_note,
+    show_note,
+    search_note,
+    sort_notes_by_tag,
 )
 from helpers.ui import style, get_bottom_toolbar
 from helpers.session import get_completer, bot_history
@@ -19,28 +35,38 @@ def parse_input(user_input):
     cmd = cmd.strip().lower()
     return cmd, *args
 
+
 print = print_formatted_text
+
 
 def main():
     """Main bot functions"""
+
     def get_toolbar():
         return get_bottom_toolbar(contacts, notes_manager)
 
     contacts = AddressBook()
     notes_manager = NotesManager()
-    session = PromptSession(completer=get_completer(NONE_COMMANDS, contacts, notes_manager, ),
-                                style=style, history=bot_history,
-                                auto_suggest=AutoSuggestFromHistory(),)
+    session = PromptSession(
+        completer=get_completer(
+            NONE_COMMANDS,
+            contacts,
+            notes_manager,
+        ),
+        style=style,
+        history=bot_history,
+        auto_suggest=AutoSuggestFromHistory(),
+    )
     try:
         contacts = load_data()
-    except FileNotFoundError: # move to handlers errors
+    except FileNotFoundError:  # move to handlers errors
         pass
     print("Welcome to the assistant bot!")
     while True:
         try:
-            user_input = session.prompt(">>> ",
-                                        bottom_toolbar=get_toolbar,
-                                        refresh_interval=0.5)
+            user_input = session.prompt(
+                ">>> ", bottom_toolbar=get_toolbar, refresh_interval=0.5
+            )
         except KeyboardInterrupt:
             # pressed ctrl+C
             user_input = "help"
@@ -83,6 +109,8 @@ def main():
             print(show_address(args, contacts))
         elif command == "add-note":
             print(add_note(notes_manager))
+        elif command == "add-tag":
+            print(add_tag(args, notes_manager))
         elif command == "edit-note":
             edit_note(args, notes_manager)
         elif command == "delete-note":
@@ -101,6 +129,7 @@ def main():
         else:
             print("Invalid command.")
         session.completer = get_completer(NONE_COMMANDS, contacts, notes_manager)
+
 
 if __name__ == "__main__":
     main()

--- a/input_handlers/add_note.py
+++ b/input_handlers/add_note.py
@@ -3,11 +3,9 @@ from models import Note
 
 
 @input_error
-def add_note(notes_manager):
-    title = input("Enter the title of the note: ")
-    description = input("Enter the description of the note: ")
-    tag_input = input("Enter the tag(s) for the note separated by comma: ")
-    tag = [tag.strip() for tag in tag_input.split(",")]
-    note = Note(title, description, tag=tag)
+def add_note(args, notes_manager):
+    title = args[0]
+    description = " ".join(args[1:])
+    note = Note(title, description)
     notes_manager.add_note(note)
-    return "Note added successfully!"
+    return "Note added"

--- a/input_handlers/add_tag.py
+++ b/input_handlers/add_tag.py
@@ -1,0 +1,12 @@
+from input_error import input_error
+
+
+@input_error
+def add_tag(args, notes_manager):
+    note_id = int(args[0])
+    tags = args[1:]
+    for note in notes_manager.notes:
+        if note.note_id == note_id:
+            note.tag.extend(tags)
+            return f"Tag {', '.join(tags)} added to note with ID {note_id}."
+    return "Note not found."

--- a/input_handlers/edit_note.py
+++ b/input_handlers/edit_note.py
@@ -3,31 +3,26 @@ from input_error import input_error
 
 @input_error
 def edit_note(args, notes_manager):
-    if args:
-        note_id = int(args[0])
-        for note in notes_manager.notes:
-            if note.note_id == note_id:
-                title = input(
-                    f"Current title: {note.title}\nEnter the new title of the note (or press Enter to keep the current title): "
-                )
-                if title:
-                    note.title = title
+    if len(args) < 2:
+        print("Usage: edit-note <note_id> <field> <new_value>")
+        return
 
-                description = input(
-                    f"Current description: {note.description}\nEnter the new description of the note (or press Enter to keep the current description): "
-                )
-                if description:
-                    note.description = description
+    note_id = int(args[0])
+    field = args[1].lower()
+    new_value = " ".join(args[2:])
 
-                tag_input = input(
-                    f"Current tag(s): {', '.join(note.tag)}\nEnter the new tag(s) for the note separated by comma (or press Enter to keep the current tag(s)): "
-                )
-                if tag_input:
-                    tag = [tag.strip() for tag in tag_input.split(",")]
-                    note.tag = tag
-
-                return print("Note edited successfully!")
-        else:
-            print("Note not found.")
+    for note in notes_manager.notes:
+        if note.note_id == note_id:
+            if field == "title":
+                note.title = new_value
+                return print(f"Title for note {note_id} changed")
+            elif field == "description":
+                note.description = new_value
+                return print(f"Description for note {note_id} changed")
+            elif field == "tag":
+                note.tag = new_value.split(",")
+                return print(f"Tag for note {note_id} changed")
+            else:
+                return print("Invalid field. Allowed fields: title, description, tag.")
     else:
-        print("Usage: edit-note <note_id>")
+        return "Note not found."


### PR DESCRIPTION
- Removed user inputs from add_note i edit_note. Added new handler for tags add_tag. The note is creating now in two steps:
1. add_note takes input from parser where user has to enter Title and Description
2. add_tag adding a tug to the list of tags. Also takes input from parser where user has to enter note_id and tags separated by space. If add tags separated by comma it will be two commas after the tag

- edit_note also takes input from parser and can change title, description or tag. The syntax of input is quite complicated:
Usage: edit-note <note_id> <'field'> <new_value>. Where <'field'> could be only title, description or tag